### PR TITLE
Fix #19 - Add Rounding to Custom Caste

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
                                 <input type="range" class="custom-range" min="0" max="1" step="0.005"
                                     v-model="noblePercent" />
                             </div>
-                            <div class="col-sm">{{ noblePercent * 100 }}%</div>
+                            <div class="col-sm">{{ Math.round(( noblePercent * 100 + Number.EPSILON) * 100) / 100 }}%</div>
                         </div>
                         <div class="row">
                             <label class="form-label text-light col-sm-4">Mercantile</label>
@@ -67,7 +67,7 @@
                                 <input type="range" class="custom-range" min="0" max="1" step="0.005"
                                     v-model="mercantilePercent" />
                             </div>
-                            <div class="col-sm">{{ mercantilePercent * 100 }}%</div>
+                            <div class="col-sm">{{ Math.round(( mercantilePercent * 100 + Number.EPSILON) * 100) / 100 }}%</div>
                         </div>
                         <div class="row">
                             <label class="form-label text-light col-sm-4">Tradesperson</label>
@@ -75,7 +75,7 @@
                                 <input type="range" class="custom-range" min="0" max="1" step="0.005"
                                     v-model="tradePercent" />
                             </div>
-                            <div class="col-sm">{{ tradePercent * 100 }}%</div>
+                            <div class="col-sm">{{ Math.round(( tradePercent * 100 + Number.EPSILON) * 100) / 100 }}%</div>
                         </div>
                         <div class="row">
                             <label class="form-label text-light col-sm-4">Peasant</label>
@@ -83,7 +83,7 @@
                                 <input type="range" class="custom-range" min="0" max="1" step="0.005"
                                     v-model="peasantPercent" />
                             </div>
-                            <div class="col-sm">{{ peasantPercent * 100 }}%</div>
+                            <div class="col-sm">{{ Math.round(( peasantPercent * 100 + Number.EPSILON) * 100) / 100 }}%</div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Add rounding to the Custom Caste by using Math.round() in
combination with Number.EPSILON to avoid any floating
point rounding issues typical of Javascript.

See: https://stackoverflow.com/questions/11832914/how-to-round-to-at-most-2-decimal-places-if-necessary

See fix with 3.5%
![Screenshot 2022-04-11 at 22-01-42 Fantasy City Generator](https://user-images.githubusercontent.com/13881184/162864107-2351ddc6-90d8-44ce-a1ee-b9a3d6f88807.png)

